### PR TITLE
CConv: fix free vars collecting for non-rec let

### DIFF
--- a/compiler/CConv.ml
+++ b/compiler/CConv.ml
@@ -62,8 +62,7 @@ let free_vars_of_expr =
     | EVar s -> String_set.add s acc
     | EIf (c, th, el) -> helper (helper (helper acc c) th) el
     | EApp (l, r) -> helper (helper acc l) r
-    | ELet (NonRecursive, _, rhs, wher) -> helper (helper acc rhs) wher
-    | ELet (Recursive, pat, rhs, wher) ->
+    | ELet (_, pat, rhs, wher) ->
       String_set.diff (helper (helper acc rhs) wher) (vars_from_pattern pat)
     | ETuple (a, b, es) -> List.fold_left helper (helper (helper acc a) b) es
     | ELam (pat, rhs) -> SS.diff (helper acc rhs) (vars_from_pattern pat)

--- a/tests/cconv/Nested_let.t
+++ b/tests/cconv/Nested_let.t
@@ -7,3 +7,15 @@
   After CCovv.
   let id x = x
   let main = id 0
+
+  $ cat << EOF | ./REPL.exe -
+  > let f x =
+  > let rec aux n y =
+  >    let m = aux (n - 1) in
+  >    m y in
+  >  aux x 0 
+  > EOF
+  Parsed: let f x = let rec aux n y = let m = aux (n - 1) in m y in aux x 0
+  After CCovv.
+  let aux n y = let m = aux (n - 1) in m y
+  let f x = aux x 0


### PR DESCRIPTION
remove variables bound by non-rec let from free vars