### PR TITLE
SoN MVP

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          submodules: true
           fetch-depth: 1
 
       - name: Install dependencies via Makefile

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "back/son/irml/ir"]
+	path = back/son/irml/ir
+	url = https://github.com/ns-58/son_c

--- a/back/son/dune
+++ b/back/son/dune
@@ -1,0 +1,15 @@
+(library
+ (name son_impl)
+ (modules son_impl)
+ (wrapped false)
+ (libraries cconv compile_lib irml))
+
+(rule
+ (target rukaml_stdlib.o)
+ (enabled_if
+  (not
+   (= none %{read:../../cc_son})))
+ (deps
+  (:src rukaml_stdlib.c))
+ (action
+  (system "%{read:../../cc_son} -c %{src} -o %{target}")))

--- a/back/son/irml/Doc.md
+++ b/back/son/irml/Doc.md
@@ -1,0 +1,202 @@
+# IRML
+Данный модуль является OCaml оберткой (wrapper) для [форка](https://github.com/ns-58/son_c) репозитория с фреймворком для JIT-компиляции, онсованном на графовом представлении программы Sea-Of-Nodes  ([оригинальный репозиторий](https://github.com/dstogov/ir)).
+
+
+## Структура
+Связывания для функций и структур фреймворка находятся в файле [`bindings.ml`](bindings.ml)
+
+Необходимые константы (компиляционые флаги, аргументы-типы для создания вершин и тд) находятся в файле [`consts.ml`](consts.ml)
+
+Вспомогательные функции находятся в файле  [`helpers.ml`](helpers.ml)
+
+## Сборка
+Подтягиваем файлы из форка:
+
+``` fish
+git submodule update --init 
+```
+
+Сборка модуля:
+
+``` fish
+dune build
+```
+
+## Использование
+(из под x86_64 для x86_64)
+
+Грубый план:
+
+    1. Построение графа для функции (в т.ч. сопутствующие peephole-оптимизации, такие как свертка констант, удаление общих подвыражений (cse) и т.п.)
+
+    2. Оптимизации
+
+    3. Компиляция в память с помощью DinAsm (пока что единственный способ компиляции, предоставляемый фреймворком)
+
+    4. Дизассемблирование (чтобы получить ассемблерный файл)
+
+
+На примере компиляции программы, печатающей факториал от 5, продемонстрируем  назначение имеющихся связываний, констант и вспомогательных функций:
+
+### Строим граф функции, вычисляющей факториал
+Для рекурсивных функций необходимо создавать thunk (память в которую, мы "обещаем" записать адрес функции в памяти после этапа DynAsm), для того чтобы функция могла использовать его, например, в вызовах. 
+С помощью функций из вспомогательного модуля `Code_buf` предварительно выделяем 10 KB для thunk'ов, создаем thunk для адреса функции factorial и сообщаем о его добавлении дизассемблеру:
+
+``` ocaml
+let open Helpers in
+let code_buf = Code_buf.create 10240 in
+let th, size = Code_buf.add_thunk code_buf in
+ir_disasm_add_symbol_w "factorial" th size;
+
+```
+
+Инициализируем граф: создаем контекст, проверяем, что фреймворк может работать в текущем окружении, добавляем компил. флаги и выделяем начальные буферы для хранения 16 и 48 констант и вершин соответственно:
+```ocaml
+let open Bindings in
+let ctx = ir_create_ctx () in
+ir_consistency_check ();
+let flags =
+    let ( + ) = Unsigned.UInt32.add in
+    Consts.(ir_function + ir_opt_folding + ir_opt_cfg + ir_opt_codegen)
+in
+let consts, insns = 16l, 48l in
+ir_init ctx flags consts insns;
+```
+
+Теперь строим граф для функции factorial. Функции вида `ir_emit...` просто добавляют вершину в граф, в то время как `ir_fold...` перед добавлением запускают серию peephole-оптимизаций для добавляемой вершины. Цифра в конце названия функции отвечает за кол-во входящих ребер (суммарно  control-flow и data-flow; control-flow всегда передаются в начале). 
+Тип вершины определяется константой.
+
+Создаём стартовую вершину, вершину для единственного параметра (1 обозначает порядковый номер параметра слева направо) и вершину для константы 1:
+``` ocaml
+let open Bindings in
+let start = ir_emit0 ctx Consts.ir_start in
+let n = ir_param ctx Consts.ir_i64 start "n" 1 in
+let one =  ir_fold1 ctx Consts.ir_copy_i64 @@ ir_const_i64 ctx 1L in
+```
+Ветвление 'if n <= 1 then 1 ...':
+
+If вершина принимает ребро из текущей control вершины (здесь start) и из data вершины, сооветствующей условию перехода (здесь создается с помощью `ir_fold2`).
+
+Каждая ветка начинается с вершины-проекции If: `Consts.ir_if_true` или `Consts.ir_if_false` и заканчивается end вершиной, которая так же принимает ребро из текущей control вершины (здесь tr)
+``` ocaml
+let open Bindings in
+let br = ir_emit2 ctx Consts.ir_if start @@ ir_fold2 ctx Consts.ir_le n one 
+let tr = ir_emit1 ctx Consts.ir_if_true br in
+let one' = ir_fold1 ctx Consts.ir_copy_i64 @@ ir_const_i64 ctx 1L in 
+let end_tr = ir_emit1 ctx Consts.ir_end tr in
+```
+Теперь 'else n * fac (n - 1)':
+
+Суффикс константы вызова (здесь i64) обозначает тип возвращаемого значения.
+
+Полученный в самом начале адрес thunk'а используется как адрес вызываемой функции (используется `ir_const_addr_w`).
+
+```ocaml
+let open Bindings in
+  let fls = ir_emit1 ctx Consts.ir_if_false cond in
+  let pred = ir_fold2 ctx Consts.ir_sub_i64 n one in
+  let call = ir_emit3 ctx Consts.ir_call1_i64 fls (ir_const_addr_w ctx th) pred in
+  let mul =  ir_fold2 ctx Consts.ir_mul_i64 n call in 
+  let end_fl = ir_emit1 ctx Consts.ir_end call in
+```
+> [!NOTE] Если у функции больше одного аргумента, то Call-вершина принимает более 3 ребер (1 от control вершины, по 1 от data вершины для адреса функции и для каждого из аргументов), и необходимо использовать функции `ir_emitN` (4 отвечает за колиество принимаемых ребер) в паре с `ir_set_op`:
+```ocaml
+    (* ЭТО ОТСТУПЛЕНИЕ ОТ ФАКТОРИАЛА*)
+    let open Bindings in
+    let call = ir_emitN ctx Consts.ir_call_i64 4l  in
+    ir_set_op ctx call 1l control;
+    ir_set_op ctx call 2l f;
+    ir_set_op ctx call 3l a1;
+    ir_set_op ctx call 4l a1;
+```
+
+Наконец, ветки сливаются с помощью Merge (принимает ребра от end вершин мз кажой ветки) и Phi вершин (для сливаемого значения), функция возврашает значение с помощью Return вершины (здесь m используется как актуальная control вершина), а ребро до Return вершины добавляется в стартовую вершину:
+```ocaml
+  let open Bindings in
+  let m = ir_emit2  ctx Consts.ir_merge2 end_tr end_fl in
+  let phi = ir_emit3 ctx Consts.ir_phi2_i64 m one' mul in
+  let ret = ir_emit2 ctx Consts.ir_return m phi in
+  ir_set_op ctx start 1l ret
+```
+
+### Оптимизации и компиляция функции в память
+
+Оптимизации и вспомогательные построения:
+```ocaml
+  let open Bindings in
+  ir_build_def_use_lists ctx;
+  let _ = ir_sccp ctx in
+  ir_build_cfg ctx;
+  ir_build_dominators_tree ctx;
+  ir_find_loops ctx;
+```
+[Эффективно распределяем data вершины по базовым блокам ](https://bernsteinbear.com/assets/img/click-gvn.pdf):
+```ocaml
+
+  Bindings.ir_gcm ctx;
+```
+Scheduling, распределение регистров, выбор инструкций:
+```ocaml
+  let open Bindings in
+  ir_schedule ctx;
+  ir_match ctx;
+  ir_assign_virtual_registers ctx;
+  ir_compute_live_ranges ctx;
+  ir_coalesce ctx;
+  ir_reg_alloc ctx;
+  ir_schedule_blocks ctx;
+```
+Компиляция в память:
+```ocaml
+let open Bindings in
+let fac_sz_buf = Helpers.size_buf () in
+let fac_entry = ir_emit_code ctx fac_sz_buf in
+```
+
+Записываем полученный адрес в выделенный ранее thunk и сохраняем контекст (понадобится при дизассемблировании):
+```ocaml
+let open Helpers
+let open Bindings
+Code_buf.fix_thunk code_buf th entry;
+ir_disasm_add_symbol_w "factorial" entry size;
+let fac_ctx = ctx in
+```
+
+### Подготовка к  дизассемблированию, использование cторонних функций (например, runtime)
+
+Открываем файл для результата компиляции в ассмеблер 
+```ocaml
+let s_out = Bindings.fopen 'out.s' "w" in
+```
+В main нам понадобится функция печати. Предположим, что она есть в другом ассемблерном файле, с которым мы позже собираемся слинковаться и называется print.
+
+Явно импортируем нужную функцию в асcемблерный файл и создаем thunk:
+``` ocaml
+ignore @@ fprintf s_out (".extern " ^ asm_name ^ "\n");
+let th, sz = add_thunk code_buf in
+ir_disasm_add_symbol_w asm_name th sz;
+```
+В этот thunk мы не будем писать, так как так и не узнаем нужный адрес до линковки.
+
+Объявляем глобальной функцию main:
+
+```ocaml
+ignore @@ fprintf s_out ".global main\n\n";
+
+```
+
+### Дизассемблирование
+Пропустим пояснения, относительно построения и компиляции main. В качестве адреса функции factorial в ней по прежнему нужно использовать (ссылку на) thunk.
+
+```ocaml
+...
+let main_sz_buf = ... in
+let main_entry = ... in
+let main_ctx = ... in
+```
+Вызов дизассемблера для функций:
+```ocaml
+ignore @@ ir_disasm "factorial" fac_entry fac_sz_buf false fac_ctx s_out;
+ignore @@ ir_disasm "main" main_entry main_sz_buf false man_ctx s_out;
+
+```

--- a/back/son/irml/bindings.ml
+++ b/back/son/irml/bindings.ml
@@ -1,0 +1,133 @@
+(* Hack needed to make symbols available, see constfun's comment here
+ * https://github.com/ocamllabs/ocaml-ctypes/issues/541 *)
+external _force_link_ : unit -> unit = "ir_regs_number"
+external _force_link_ : unit -> unit = "ir_consistency_check"
+external _force_link_ : unit -> unit = "ir_disasm_add_symbol_w"
+external _force_link_ : unit -> unit = "ir_sccp"
+external _force_link_ : unit -> unit = "ir_save"
+
+open Ctypes
+
+open Foreign
+
+(* some stdio.h things *)
+
+type file_ptr = unit ptr
+let file_ptr : file_ptr typ = ptr void
+
+let fopen = foreign "fopen" (string @-> string @-> returning file_ptr)
+let fclose = foreign "fclose" (file_ptr @-> returning int)
+let fprintf = foreign "fprintf" (file_ptr @-> string @-> returning int)
+
+(* SoN *)
+
+type ir_ctx_ptr = unit ptr
+
+let ir_ctx_ptr : ir_ctx_ptr typ = ptr void
+
+type code_buffer
+let code_buffer : code_buffer structure typ = structure "code_buffer"
+
+let start = field code_buffer "start" @@ ptr void
+let endd = field code_buffer "end" @@ ptr void
+
+let pos = field code_buffer "pos" @@ ptr void;;
+
+seal code_buffer
+
+(*TODO: due definitions from ir.h as comments? *)
+let ir_param =
+  foreign
+    "ir_param"
+    (ir_ctx_ptr @-> uint16_t @-> int32_t @-> string @-> int @-> returning int32_t)
+;;
+let ir_const_i64 = foreign "ir_const_i64" (ir_ctx_ptr @-> int64_t @-> returning int32_t)
+
+let ir_const_addr_w =
+  foreign "ir_const_addr_w" (ir_ctx_ptr @-> ptr void @-> returning int32_t)
+;;
+
+let ir_fold1 =
+  foreign "ir_fold1" (ir_ctx_ptr @-> uint32_t @-> int32_t @-> returning int32_t)
+;;
+let ir_fold2 =
+  foreign
+    "ir_fold2"
+    (ir_ctx_ptr @-> uint32_t @-> int32_t @-> int32_t @-> returning int32_t)
+;;
+let ir_emit0 = foreign "ir_emit0" (ir_ctx_ptr @-> uint32_t @-> returning int32_t)
+let ir_emit1 =
+  foreign "ir_emit1" (ir_ctx_ptr @-> uint32_t @-> int32_t @-> returning int32_t)
+;;
+let ir_emit2 =
+  foreign
+    "ir_emit2"
+    (ir_ctx_ptr @-> uint32_t @-> int32_t @-> int32_t @-> returning int32_t)
+;;
+let ir_emit3 =
+  foreign
+    "ir_emit3"
+    (ir_ctx_ptr @-> uint32_t @-> int32_t @-> int32_t @-> int32_t @-> returning int32_t)
+;;
+let ir_emitN =
+  foreign "ir_emit_N" (ir_ctx_ptr @-> uint32_t @-> int32_t @-> returning int32_t)
+;;
+let ir_set_op =
+  foreign "ir_set_op" (ir_ctx_ptr @-> int32_t @-> int32_t @-> int32_t @-> returning void)
+;;
+let ir_create_ctx = foreign "ir_create_ctx" (void @-> returning ir_ctx_ptr)
+let ir_consistency_check = foreign "ir_consistency_check" (void @-> returning void)
+let ir_init =
+  foreign "ir_init" (ir_ctx_ptr @-> uint32_t @-> int32_t @-> int32_t @-> returning void)
+;;
+let ir_build_cfg = foreign "ir_build_cfg" (ir_ctx_ptr @-> returning void)
+let ir_build_dominators_tree =
+  foreign "ir_build_dominators_tree" (ir_ctx_ptr @-> returning void)
+;;
+let ir_build_def_use_lists =
+  foreign "ir_build_def_use_lists" (ir_ctx_ptr @-> returning void)
+;;
+let ir_sccp = foreign "ir_sccp" (ir_ctx_ptr @-> returning int)
+let ir_find_loops = foreign "ir_find_loops" (ir_ctx_ptr @-> returning void)
+let ir_gcm = foreign "ir_gcm" (ir_ctx_ptr @-> returning void)
+let ir_schedule = foreign "ir_schedule" (ir_ctx_ptr @-> returning void)
+let ir_match = foreign "ir_match" (ir_ctx_ptr @-> returning void)
+let ir_assign_virtual_registers =
+  foreign "ir_assign_virtual_registers" (ir_ctx_ptr @-> returning void)
+;;
+let ir_compute_live_ranges =
+  foreign "ir_compute_live_ranges" (ir_ctx_ptr @-> returning void)
+;;
+let ir_coalesce = foreign "ir_coalesce" (ir_ctx_ptr @-> returning void)
+let ir_reg_alloc = foreign "ir_reg_alloc" (ir_ctx_ptr @-> returning void)
+let ir_schedule_blocks = foreign "ir_schedule_blocks" (ir_ctx_ptr @-> returning void)
+let ir_emit_code =
+  foreign "ir_emit_code" (ir_ctx_ptr @-> ptr ulong @-> returning @@ ptr void)
+;;
+let ir_disasm_init = foreign "ir_disasm_init" (void @-> returning int)
+let ir_disasm_add_symbol_w =
+  foreign "ir_disasm_add_symbol_w" (string @-> ptr void @-> ulong @-> returning void)
+;;
+let ir_disasm =
+  foreign
+    "ir_disasm"
+    (const string
+     @-> const (ptr void)
+     @-> ulong
+     @-> bool
+     @-> ir_ctx_ptr
+     @-> file_ptr
+     @-> returning int)
+;;
+let ir_disasm_free = foreign "ir_disasm_free" (void @-> returning void)
+let ir_free = foreign "ir_free" (ir_ctx_ptr @-> returning void)
+let ir_save = foreign "ir_save" (ir_ctx_ptr @-> uint32_t @-> file_ptr @-> returning void)
+let ir_mem_mmap = foreign "ir_mem_mmap" (ulong @-> returning (ptr void))
+let ir_mem_unprotect = foreign "ir_mem_unprotect" (ptr void @-> ulong @-> returning int)
+let ir_mem_protect = foreign "ir_mem_protect" (ptr void @-> ulong @-> returning int)
+let ir_emit_thunk =
+  foreign
+    "ir_emit_thunk"
+    (ptr code_buffer @-> ptr void @-> ptr ulong @-> returning @@ ptr void)
+;;
+let ir_fix_thunk = foreign "ir_fix_thunk" (ptr void @-> ptr void @-> returning void)

--- a/back/son/irml/consts.ml
+++ b/back/son/irml/consts.ml
@@ -1,0 +1,31 @@
+let ir_i64 = Unsigned.UInt16.of_int 11
+
+open Unsigned.UInt32
+
+(*node types*)
+let ir_start = of_int 99
+let ir_return = of_int 115
+let ir_if = of_int 111
+let ir_eq = of_int 270
+let ir_ne = of_int 271
+let ir_lt = of_int 272
+let ir_ge = of_int 273
+let ir_le = of_int 274
+let ir_gt = of_int 275
+let ir_if_true = of_int 102
+let ir_if_false = of_int 103
+let ir_end = of_int 109
+let ir_merge2 = of_int 131179
+let ir_phi2_i64 = of_int 199487
+let ir_copy_i64 = of_int 2880
+let ir_add_i64 = of_int 2842
+let ir_sub_i64 = of_int 2843
+let ir_mul_i64 = of_int 2844
+let ir_div_i64 = of_int 2845
+let ir_mod_i64 = of_int 2846
+let ir_call1_i64 = of_int 199498
+let ir_call_i64 = of_int 2890
+
+(*flags*)
+let ir_function = of_int 256
+let ir_opt_folding = of_int 1048576

--- a/back/son/irml/consts.ml
+++ b/back/son/irml/consts.ml
@@ -29,3 +29,5 @@ let ir_call_i64 = of_int 2890
 (*flags*)
 let ir_function = of_int 256
 let ir_opt_folding = of_int 1048576
+let ir_opt_cfg = of_int 2097152
+let ir_opt_codegen = of_int 8388608

--- a/back/son/irml/dune
+++ b/back/son/irml/dune
@@ -1,0 +1,20 @@
+(data_only_dirs ir)
+
+(library
+ (name irml)
+ (modules bindings consts)
+ (libraries ctypes ctypes-foreign compile_lib)
+ (foreign_archives ir)
+ (c_library_flags -lm -ldl -lcapstone))
+
+(rule
+ (deps
+  (source_tree ir))
+ (targets libir.a)
+ (action
+  (no-infer
+   (progn
+    (chdir
+     ir
+     (run make all))
+    (copy ir/libir.a libir.a)))))

--- a/back/son/irml/dune
+++ b/back/son/irml/dune
@@ -3,7 +3,7 @@
 (library
  (name irml)
  (modules bindings consts)
- (libraries ctypes ctypes-foreign compile_lib)
+ (libraries ctypes ctypes-foreign)
  (foreign_archives ir)
  (c_library_flags -lm -ldl -lcapstone))
 

--- a/back/son/irml/dune
+++ b/back/son/irml/dune
@@ -2,7 +2,7 @@
 
 (library
  (name irml)
- (modules bindings consts)
+ (modules bindings consts helpers)
  (libraries ctypes ctypes-foreign)
  (foreign_archives ir)
  (c_library_flags -lm -ldl -lcapstone))

--- a/back/son/irml/dune
+++ b/back/son/irml/dune
@@ -16,5 +16,9 @@
    (progn
     (chdir
      ir
-     (run make all))
+     (run
+      make
+      all
+      ; on error run `git submodule update --init`
+      ))
     (copy ir/libir.a libir.a)))))

--- a/back/son/irml/helpers.ml
+++ b/back/son/irml/helpers.ml
@@ -1,0 +1,48 @@
+open Bindings
+let size_buf () = Ctypes.allocate Ctypes.ulong Unsigned.ULong.zero
+
+module Code_buf : sig
+  type t
+  val create : int -> t
+  val add_thunk : t -> unit Ctypes_static.ptr * Unsigned.ULong.t
+  val fix_thunk : t -> unit Ctypes_static.ptr -> unit Ctypes_static.ptr -> unit
+end = struct
+  (* buf ptr, start ptr, size *)
+  type t =
+    (code_buffer, [ `Struct ]) Ctypes.structured Ctypes.ptr
+    * unit Ctypes.ptr
+    * Unsigned.ULong.t
+  let create size =
+    let open Ctypes in
+    let buf = make code_buffer in
+    let sz_sizet = Unsigned.ULong.of_int size in
+    let st =
+      (*TODO: err hndl?*)
+      ir_mem_mmap sz_sizet
+    in
+    setf buf start st;
+    setf buf endd @@ to_voidp (from_voidp (ptr char) st +@ size);
+    setf buf pos st;
+    addr buf, st, sz_sizet
+  ;;
+
+  let add_thunk (buf, st, size) =
+    let open Ctypes in
+    let sz_buf = size_buf () in
+    (*TODO: err hndl?*)
+    ignore @@ ir_mem_unprotect st size;
+    (*TODO: err hndl?*)
+    let thunk = ir_emit_thunk buf null sz_buf in
+    (*TODO: err hndl?*)
+    ignore @@ ir_mem_protect st size;
+    thunk, !@sz_buf
+  ;;
+
+  let fix_thunk (_, st, size) th new_addr =
+    (*TODO: err hndl?*)
+    ignore @@ ir_mem_unprotect st size;
+    ir_fix_thunk th new_addr;
+    (*TODO: err hndl?*)
+    ignore @@ ir_mem_protect st size
+  ;;
+end

--- a/back/son/rukaml_stdlib.c
+++ b/back/son/rukaml_stdlib.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+void rukaml_print_int(int x)
+{
+    printf("%s %d\n", __func__, x);
+    fflush(stdout);
+}

--- a/back/son/son_impl.ml
+++ b/back/son/son_impl.ml
@@ -1,60 +1,13 @@
 open Compile_lib.ANF
 open Irml
 open Bindings
+open Helpers
 
 type value =
   | Addr of unit Ctypes_static.ptr
   | LocalNode of int32
 
 module SMap = Map.Make (String)
-
-let size_buf () = Ctypes.allocate Ctypes.ulong Unsigned.ULong.zero
-
-module Code_buf : sig
-  type t
-  val create : int -> t
-  val add_thunk : t -> unit Ctypes_static.ptr * Unsigned.ULong.t
-  val fix_thunk : t -> unit Ctypes_static.ptr -> unit Ctypes_static.ptr -> unit
-end = struct
-  (* buf ptr, start ptr, size *)
-  type t =
-    (code_buffer, [ `Struct ]) Ctypes.structured Ctypes.ptr
-    * unit Ctypes.ptr
-    * Unsigned.ULong.t
-  let create size =
-    let open Ctypes in
-    let buf = make code_buffer in
-    let sz_sizet = Unsigned.ULong.of_int size in
-    let st =
-      (*TODO: err hndl?*)
-      ir_mem_mmap sz_sizet
-    in
-    setf buf start st;
-    setf buf endd @@ to_voidp (from_voidp (ptr char) st +@ size);
-    setf buf pos st;
-    addr buf, st, sz_sizet
-  ;;
-
-  let add_thunk (buf, st, size) =
-    let open Ctypes in
-    let sz_buf = size_buf () in
-    (*TODO: err hndl?*)
-    ignore @@ ir_mem_unprotect st size;
-    (*TODO: err hndl?*)
-    let thunk = ir_emit_thunk buf null sz_buf in
-    (*TODO: err hndl?*)
-    ignore @@ ir_mem_protect st size;
-    thunk, !@sz_buf
-  ;;
-
-  let fix_thunk (_, st, size) th new_addr =
-    (*TODO: err hndl?*)
-    ignore @@ ir_mem_unprotect st size;
-    ir_fix_thunk th new_addr;
-    (*TODO: err hndl?*)
-    ignore @@ ir_mem_protect st size
-  ;;
-end
 
 let to_son env ctx pats e =
   let start = ir_emit0 ctx Consts.ir_start in

--- a/back/son/son_impl.ml
+++ b/back/son/son_impl.ml
@@ -1,0 +1,218 @@
+open Compile_lib.ANF
+open Irml
+open Bindings
+
+type value =
+  | Addr of unit Ctypes_static.ptr
+  | LocalNode of int32
+
+module SMap = Map.Make (String)
+
+let size_buf () = Ctypes.allocate Ctypes.ulong Unsigned.ULong.zero
+
+module Code_buf : sig
+  type t
+  val create : int -> t
+  val add_thunk : t -> unit Ctypes_static.ptr * Unsigned.ULong.t
+  val fix_thunk : t -> unit Ctypes_static.ptr -> unit Ctypes_static.ptr -> unit
+end = struct
+  (* buf ptr, start ptr, size *)
+  type t =
+    (code_buffer, [ `Struct ]) Ctypes.structured Ctypes.ptr
+    * unit Ctypes.ptr
+    * Unsigned.ULong.t
+  let create size =
+    let open Ctypes in
+    let buf = make code_buffer in
+    let sz_sizet = Unsigned.ULong.of_int size in
+    let st =
+      (*TODO: err hndl?*)
+      ir_mem_mmap sz_sizet
+    in
+    setf buf start st;
+    setf buf endd @@ to_voidp (from_voidp (ptr char) st +@ size);
+    setf buf pos st;
+    addr buf, st, sz_sizet
+  ;;
+
+  let add_thunk (buf, st, size) =
+    let open Ctypes in
+    let sz_buf = size_buf () in
+    (*TODO: err hndl?*)
+    ignore @@ ir_mem_unprotect st size;
+    (*TODO: err hndl?*)
+    let thunk = ir_emit_thunk buf null sz_buf in
+    (*TODO: err hndl?*)
+    ignore @@ ir_mem_protect st size;
+    thunk, !@sz_buf
+  ;;
+
+  let fix_thunk (_, st, size) th new_addr =
+    (*TODO: err hndl?*)
+    ignore @@ ir_mem_unprotect st size;
+    ir_fix_thunk th new_addr;
+    (*TODO: err hndl?*)
+    ignore @@ ir_mem_protect st size
+  ;;
+end
+
+let to_son env ctx pats e =
+  let start = ir_emit0 ctx Consts.ir_start in
+  let _, env =
+    List.fold_left
+      (fun (i, env) (APname { hum_name = name; _ }) ->
+         let n = LocalNode (ir_param ctx Consts.ir_i64 start name i) in
+         i + 1, SMap.add name n env)
+      (1, env)
+      pats
+  in
+  let rec helper e env ctrl =
+    match (e : Compile_lib.ANF.expr) with
+    | ELet (_, Tpat_var { hum_name = name; _ }, c, e) ->
+      let ctrl, data = helper_c c env ctrl in
+      helper e (SMap.add name (LocalNode data) env) ctrl
+    | EComplex c -> helper_c c env ctrl
+    | ELet _ -> assert false
+  and helper_c c env ctrl =
+    match c with
+    | CIte (c, e1, e2) ->
+      let ctrl, data = helper_c c env ctrl in
+      let cond = ir_emit2 ctx Consts.ir_if ctrl data in
+      let ctrl1, data1 = helper e1 env @@ ir_emit1 ctx Consts.ir_if_true cond in
+      let ctrl2, data2 = helper e2 env @@ ir_emit1 ctx Consts.ir_if_false cond in
+      let merge_p =
+        ir_emit2
+          ctx
+          Consts.ir_merge2
+          (ir_emit1 ctx Consts.ir_end ctrl1)
+          (ir_emit1 ctx Consts.ir_end ctrl2)
+      in
+      merge_p, ir_emit3 ctx Consts.ir_phi2_i64 merge_p data1 data2
+    | CApp (APrimitive b, i1, [ i2 ]) when is_infix_binop b ->
+      let op =
+        let open Consts in
+        match b with
+        | "=" -> ir_eq
+        | "+" -> ir_add_i64
+        | "-" -> ir_sub_i64
+        | "*" -> ir_mul_i64
+        | "/" -> ir_div_i64
+        | "<" -> ir_lt
+        | "<=" -> ir_le
+        | ">" -> ir_gt
+        | ">=" -> ir_ge
+        | _ -> failwith "new binop?"
+      in
+      ctrl, ir_fold2 ctx op (helper_imm env i1) (helper_imm env i2)
+    | CApp (APrimitive _, _, _) -> failwith "not impl yet"
+    | CApp (i0, i1, ii) ->
+      let f = helper_imm env i0 in
+      let a1 = helper_imm env i1 in
+      let aa = List.map (helper_imm env) ii in
+      let clone x = x, x in
+      clone
+        (match aa with
+         | [] -> ir_emit3 ctx Consts.ir_call1_i64 ctrl f a1
+         | _ ->
+           let len = List.length aa in
+           let call = ir_emitN ctx Consts.ir_call_i64 @@ Int32.of_int (len + 3) in
+           ir_set_op ctx call 1l ctrl;
+           ir_set_op ctx call 2l f;
+           ir_set_op ctx call 3l a1;
+           List.iteri (fun pos a -> ir_set_op ctx call (Int32.of_int (pos + 4)) a) aa;
+           call)
+    | CAtom imm -> ctrl, helper_imm env imm
+  and helper_imm env imm =
+    let const n = ir_fold1 ctx Consts.ir_copy_i64 @@ ir_const_i64 ctx @@ Int64.of_int n in
+    match imm with
+    | AUnit | AConst (PConst_bool false) -> const 0
+    | AConst (PConst_bool true) -> const 1
+    | AConst (PConst_int n) -> const n
+    | AVar { hum_name = name; _ } ->
+      (match SMap.find name env with
+       | Addr a -> ir_const_addr_w ctx a
+       | LocalNode n -> n)
+    | _ -> failwith ""
+  in
+  let ctrl, data = helper e env start in
+  let ret = ir_emit2 ctx Consts.ir_return ctrl data in
+  ir_set_op ctx start 1l ret
+;;
+
+let compile_vb env name b =
+  let pats, e = Compile_lib.ANF.group_abstractions b in
+  let argc = List.length pats in
+  assert (argc >= 1 || name = "main");
+  let ctx = ir_create_ctx () in
+  ir_consistency_check ();
+  let flags = Unsigned.UInt32.add Consts.ir_function Consts.ir_opt_folding in
+  (* init sizes for due buffers*)
+  let consts, insns = 16l, 48l in
+  ir_init ctx flags consts insns;
+  to_son env ctx pats e;
+  ir_build_def_use_lists ctx;
+  let _ = ir_sccp ctx in
+  (*todo : check if nonzero?*)
+  ir_build_cfg ctx;
+  ir_build_dominators_tree ctx;
+  ir_find_loops ctx;
+  ir_gcm ctx;
+  ir_schedule ctx;
+  ir_match ctx;
+  ir_assign_virtual_registers ctx;
+  ir_compute_live_ranges ctx;
+  ir_coalesce ctx;
+  ir_reg_alloc ctx;
+  ir_schedule_blocks ctx;
+  (* Maybe later we'd like to add: ir_mem2ssa *)
+  let sz_buf = size_buf () in
+  let entry = ir_emit_code ctx sz_buf in
+  entry, ctx, Ctypes.( !@ ) sz_buf
+;;
+
+let codegen vbs out_file =
+  let s_out = fopen out_file "w" in
+  let open Code_buf in
+  let code_buf =
+    create 10240
+    (*10 KB for thunks*)
+  in
+  let add_externals =
+    List.fold_left
+    @@ fun env (asm_name, name) ->
+    (*TODO: err hndl?*)
+    ignore @@ fprintf s_out (".extern " ^ asm_name ^ "\n");
+    (* (thunk) never be fixed *)
+    let th, sz = add_thunk code_buf in
+    ir_disasm_add_symbol_w asm_name th sz;
+    SMap.add name (Addr th) env
+  in
+  let init_env = add_externals SMap.empty [ "rukaml_print_int", "print" ] in
+  (*TODO: err hndl?*)
+  ignore @@ fprintf s_out ".global main\n\n";
+  let fin (name, entry, ctx, size) =
+    ignore @@ ir_disasm name entry size false ctx s_out;
+    ir_free ctx
+  in
+  List.iter fin
+  @@ snd
+  @@ List.fold_left_map
+       (fun glob_env -> function
+          | Frontend.Parsetree.Recursive, ({ hum_name = name; _ } : Frontend.Ident.t), b
+            ->
+            let th, sz = add_thunk code_buf in
+            ir_disasm_add_symbol_w name th sz;
+            let glob_env' = SMap.add name (Addr th) glob_env in
+            let entry, ctx, size = compile_vb glob_env' name b in
+            Code_buf.fix_thunk code_buf th entry;
+            ir_disasm_add_symbol_w name entry size;
+            SMap.add name (Addr entry) glob_env, (name, entry, ctx, size)
+          | NonRecursive, { hum_name = name; _ }, b ->
+            let entry, ctx, size = compile_vb glob_env name b in
+            ir_disasm_add_symbol_w name entry size;
+            SMap.add name (Addr entry) glob_env, (name, entry, ctx, size))
+       init_env
+       vbs;
+
+  ignore @@ fclose s_out
+;;

--- a/back/son/son_impl.ml
+++ b/back/son/son_impl.ml
@@ -145,7 +145,10 @@ let compile_vb env name b =
   assert (argc >= 1 || name = "main");
   let ctx = ir_create_ctx () in
   ir_consistency_check ();
-  let flags = Unsigned.UInt32.add Consts.ir_function Consts.ir_opt_folding in
+  let flags =
+    let ( + ) = Unsigned.UInt32.add in
+    Consts.(ir_function + ir_opt_folding + ir_opt_cfg + ir_opt_codegen)
+  in
   (* init sizes for due buffers*)
   let consts, insns = 16l, 48l in
   ir_init ctx flags consts insns;

--- a/discover.ml
+++ b/discover.ml
@@ -142,5 +142,16 @@ let () =
   in
   let toolchain_llvm = discover_toolchain cfg defaults_llvm ~suffix:"llvm" in
   export_toolchain toolchain_llvm ~suffix:"llvm";
-  print_toolchain toolchain_llvm
+  print_toolchain toolchain_llvm;
+
+  let defaults_son =
+    { cc = { path = gcc_amd64; flags = "-g -fPIC -Wall -Wpedantic" }
+    ; as_ = { path = gcc_amd64; flags = "-x assembler -c" }
+    ; ld = { path = gcc_amd64; flags = "" }
+    ; run = { path = ""; flags = "" }
+    }
+  in
+  let toolchain_son = discover_toolchain cfg defaults_son ~suffix:"son" in
+  export_toolchain toolchain_son ~suffix:"son";
+  print_toolchain toolchain_son
 ;;

--- a/driver/driver.ml
+++ b/driver/driver.ml
@@ -121,6 +121,12 @@ module Compiler = struct
     k (Code f)
   ;;
 
+  (** Generate code for AMD64 via sea-of-nodes *)
+  let son (ANF stru) =
+    let f ~path = Son_impl.codegen stru path in
+    k (Code f)
+  ;;
+
   (** Generate code for LLVM *)
   let llvm (ANF stru) =
     let f ~path = LLVM_impl.codegen stru path |> Result.ok_or_failwith in
@@ -167,6 +173,8 @@ module Target = struct
 
   let rv64 table p = (Intermediate.anftree table p) rv64
   let amd64 table p = (Intermediate.anftree table p) amd64
+  let son table p = (Intermediate.anftree table p) son
+
   let llvm table p = (Intermediate.anftree table p) llvm
 
   let finish target p = (target p) (to_file p.out_path)
@@ -176,6 +184,7 @@ module Target = struct
       (module String)
       [ "rv64", finish (rv64 table)
       ; "amd64", finish (amd64 table)
+      ; "son", finish (son table)
       ; "llvm", finish (llvm table)
       ; "parsetree", finish Intermediate.parsetree
       ; ("cps", fun p -> finish Intermediate.cpstree { p with cps = true })

--- a/driver/dune
+++ b/driver/dune
@@ -1,4 +1,12 @@
 (executable
  (name driver)
  (public_name driver)
- (libraries base stdio Frontend compile_lib rv64_impl amd64_impl llvm_impl))
+ (libraries
+  base
+  stdio
+  Frontend
+  compile_lib
+  rv64_impl
+  amd64_impl
+  llvm_impl
+  son_impl))

--- a/dune
+++ b/dune
@@ -15,6 +15,10 @@
   as_amd64
   ld_amd64
   run_amd64
+  cc_son
+  as_son
+  ld_son
+  run_son
   cc_rv64
   as_rv64
   ld_rv64

--- a/rukaml.opam
+++ b/rukaml.opam
@@ -44,7 +44,7 @@ depexts: [
   [ "nasm" "gcc-13" "pkg-config"
     "llvm-16-dev" "clang-16"
     "binutils-riscv64-linux-gnu" "gcc-13-riscv64-linux-gnu"
-    "libcunit1-dev"
+    "libcunit1-dev" "libcapstone-dev"
   ] { os-distribution = "ubuntu" }
   [ "qemu-user-static" ] { os-distribution = "ubuntu" & os-version <= "25.04" }
   [ "qemu-user" ] { os-distribution = "ubuntu" & os-version >= "25.10" }

--- a/testsuite/tests/add.ml
+++ b/testsuite/tests/add.ml
@@ -1,6 +1,6 @@
 (*
 test
-  (targets rv64 amd64)
+  (targets rv64  son amd64)
   (run (stdout "rukaml_print_int 11"))
 *)
 

--- a/testsuite/tests/empty.ml
+++ b/testsuite/tests/empty.ml
@@ -1,2 +1,2 @@
-(* test (targets llvm rv64 amd64) (run) *)
+(* test (targets llvm rv64 amd64 son) (run) *)
 let main = 0

--- a/testsuite/tests/fac.ml
+++ b/testsuite/tests/fac.ml
@@ -1,6 +1,6 @@
 (*
 test
-  (targets rv64 amd64)
+  (targets rv64 amd64 son)
   (flags () (--cps) (--cps --caa))
   (run (stdout "rukaml_print_int 24"))
 *)

--- a/testsuite/tests/fac_acc.ml
+++ b/testsuite/tests/fac_acc.ml
@@ -1,6 +1,6 @@
 (*
 test
-  (targets rv64)
+  (targets rv64 son)
   (flags () (--cps) (--cps --caa))
   (run (stdout "rukaml_print_int 24"))
 *)

--- a/testsuite/tests/fib.ml
+++ b/testsuite/tests/fib.ml
@@ -1,6 +1,6 @@
 (*
 test
-  (targets rv64 amd64)
+  (targets rv64 amd64 son)
   (flags () (--cps) (--cps --caa))
   (run (stdout "rukaml_print_int 21"))
 *)

--- a/testsuite/tests/fib_acc.ml
+++ b/testsuite/tests/fib_acc.ml
@@ -1,6 +1,6 @@
 (*
 test
-  (targets rv64 amd64)
+  (targets rv64 amd64 son)
   (flags () (--cps) (--cps --caa))
   (run (stdout "rukaml_print_int 3"))
 *)

--- a/testsuite/tests/fib_cmp.ml
+++ b/testsuite/tests/fib_cmp.ml
@@ -1,6 +1,6 @@
 (*
 test
-  (targets rv64)
+  (targets rv64 son)
   (run (stdout "rukaml_print_int 21"))
 *)
 

--- a/testsuite/tests/if.ml
+++ b/testsuite/tests/if.ml
@@ -1,6 +1,6 @@
 (*
 test
-  (targets amd64)
+  (targets amd64 son)
   (run (stdout "rukaml_print_int 10"))
 *)
 

--- a/testsuite/tests/ite.ml
+++ b/testsuite/tests/ite.ml
@@ -1,6 +1,6 @@
 (*
 test
-  (targets rv64 amd64)
+  (targets rv64 amd64 son)
   (run
     (stdout
       "rukaml_print_int 2"

--- a/testsuite/tests/large.ml
+++ b/testsuite/tests/large.ml
@@ -1,6 +1,6 @@
 (*
 test
-  (targets (anf promote) (amd64 promote))
+  (targets (anf promote) (amd64 promote) son)
   (run (stdout "rukaml_print_int 42" "rukaml_print_int 0"))
 *)
 

--- a/testsuite/tests/loop.ml
+++ b/testsuite/tests/loop.ml
@@ -1,6 +1,6 @@
 (*
 test
-  (targets rv64 amd64)
+  (targets rv64 amd64 son)
   (run
     (stdout
       "rukaml_print_int 0"

--- a/testsuite/tests/pass_print0.ml
+++ b/testsuite/tests/pass_print0.ml
@@ -1,6 +1,6 @@
 (*
 test
-  (targets rv64 amd64)
+  (targets rv64 amd64 son)
   (flags () (--cps) (--cps --caa))
   (run
     (stdout

--- a/testsuite/tests/print.ml
+++ b/testsuite/tests/print.ml
@@ -1,6 +1,6 @@
 (*
 test
-  (targets amd64)
+  (targets amd64 son)
   (run (stdout "rukaml_print_int 20"))
 *)
 

--- a/testsuite/tests/printk.ml
+++ b/testsuite/tests/printk.ml
@@ -1,6 +1,6 @@
 (*
 test
-  (targets rv64 amd64)
+  (targets rv64 amd64 son)
   (run (stdout "rukaml_print_int 101"))
 *)
 


### PR DESCRIPTION
sea-of-nodes backend mvp (gc and related things are absent)

 [this](https://github.com/dstogov/ir) repo [fork](https://github.com/ns-58/son_c) is used via ctypes ffi.

NOTE: notice that failed tests are work fine without -cps and -caa flags (i.e. there are no *.fl0.* files on fails list, only *.fl1.* and *.fl2.* ones)

DOCS for IRML module: [back/son/irml/Doc.md](https://github.com/Kakadu/rukaml/pull/25/changes#diff-a602f93a567c60f70a08e172d27710f500bd0d8e1d7a907e82f12193427ca252)

run:
```fish
 dune exec driver -- <path_to_src_file> --target son -o <asm_name.s>
 ```

test:
``` fish
make testsuite
```

